### PR TITLE
Feature/reservation sync fix

### DIFF
--- a/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
@@ -32,4 +32,39 @@ public class ChargerEntity extends BasicEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="ChargingStation_id")
     private ChargingStationEntity station;
+
+    @Version
+    private Long version;
+
+    public void reserve() {
+        if (this.status == ChargerStatus.AVAILABLE) {
+            this.status = ChargerStatus.RESERVED;
+        } else {
+            throw new IllegalStateException("사용할 수 없는 충전기입니다.");
+        }
+    }
+
+    public void start() {
+        if (this.status == ChargerStatus.RESERVED) {
+            this.status = ChargerStatus.CHARGING;
+        } else {
+            throw new IllegalStateException("충전을 시작할 수 없는 상태입니다.");
+        }
+    }
+
+    public void cancel() {
+        if (this.status == ChargerStatus.RESERVED) {
+            this.status = ChargerStatus.AVAILABLE;
+        } else {
+            throw new IllegalStateException("예약을 취소할 수 없는 상태입니다.");
+        }
+    }
+
+    public void complete() {
+        if (this.status == ChargerStatus.CHARGING) {
+            this.status = ChargerStatus.AVAILABLE;
+        } else {
+            throw new IllegalStateException("충전을 완료할 수 없는 상태입니다.");
+        }
+    }
 }

--- a/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
@@ -32,7 +32,4 @@ public class ChargerEntity extends BasicEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="ChargingStation_id")
     private ChargingStationEntity station;
-
-    @OneToMany(mappedBy = "charger", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<ReservationEntity> reservationEntityList;
 }

--- a/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerEntity.java
@@ -36,35 +36,15 @@ public class ChargerEntity extends BasicEntity {
     @Version
     private Long version;
 
-    public void reserve() {
-        if (this.status == ChargerStatus.AVAILABLE) {
-            this.status = ChargerStatus.RESERVED;
-        } else {
-            throw new IllegalStateException("사용할 수 없는 충전기입니다.");
-        }
+    public void available() {
+        this.status = ChargerStatus.AVAILABLE;
     }
 
-    public void start() {
-        if (this.status == ChargerStatus.RESERVED) {
-            this.status = ChargerStatus.CHARGING;
-        } else {
-            throw new IllegalStateException("충전을 시작할 수 없는 상태입니다.");
-        }
+    public void charging() {
+        this.status = ChargerStatus.CHARGING;
     }
 
-    public void cancel() {
-        if (this.status == ChargerStatus.RESERVED) {
-            this.status = ChargerStatus.AVAILABLE;
-        } else {
-            throw new IllegalStateException("예약을 취소할 수 없는 상태입니다.");
-        }
-    }
-
-    public void complete() {
-        if (this.status == ChargerStatus.CHARGING) {
-            this.status = ChargerStatus.AVAILABLE;
-        } else {
-            throw new IllegalStateException("충전을 완료할 수 없는 상태입니다.");
-        }
+    public void reserved() {
+        this.status = ChargerStatus.RESERVED;
     }
 }

--- a/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerStatus.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/charger/entity/ChargerStatus.java
@@ -19,7 +19,8 @@ public enum ChargerStatus implements CodedEnum<String> {
     AVAILABLE("2", "사용가능"),
     CHARGING("3", "충전중"),
     OUT_OF_SERVICE("4", "운영중지"),
-    UNDER_MAINTENANCE("5", "점검중");
+    UNDER_MAINTENANCE("5", "점검중"),
+    RESERVED("6", "예약중");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/dto/response/ReservationDetailResponse.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/dto/response/ReservationDetailResponse.java
@@ -10,14 +10,14 @@ import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
 import java.time.LocalDateTime;
 
 public record ReservationDetailResponse(
-       Long id,
-       String reservationNumber,
-       String vehicleNumber,
-       LocalDateTime startAt,
-       LocalDateTime endAt,
-       ReservationStatus status,
-       LocalDateTime chargerStartAt,
-       ChargerDetail charger
+        Long id,
+        String reservationNumber,
+        String vehicleNumber,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        ReservationStatus status,
+        LocalDateTime chargerStartAt,
+        ChargerDetail charger
 ) {
 
     public record ChargerDetail(

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/entity/ReservationEntity.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/entity/ReservationEntity.java
@@ -73,12 +73,8 @@ public class ReservationEntity extends BasicEntity {
         this.chargerStartAt = LocalDateTime.now();
     }
 
-    public void markAsFailed() {
+    public void failed() {
         this.status = ReservationStatus.FAILED;
-    }
-
-    public boolean isExpired() {
-        return LocalDateTime.now().isAfter(this.endAt);
     }
 
     public void cancel() {
@@ -87,5 +83,9 @@ public class ReservationEntity extends BasicEntity {
 
     public void complete() {
         this.status = ReservationStatus.COMPLETED;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.endAt);
     }
 }

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/event/ChargerStatusEventListener.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/event/ChargerStatusEventListener.java
@@ -1,0 +1,32 @@
+package com.projectX.ChargerReserv.domain.reservation.event;
+
+import com.projectX.ChargerReserv.domain.charger.entity.ChargerEntity;
+import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
+import com.projectX.ChargerReserv.global.error.NoExistException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class ChargerStatusEventListener {
+
+    private final ChargerRepository chargerRepository;
+
+    @EventListener
+    @Transactional
+    public void handleReservationEvent(ReservationEvent event) {
+        ChargerEntity charger = chargerRepository.findById(event.chargerId())
+                .orElseThrow(() -> new NoExistException("충전기를 찾을 수 없습니다."));
+
+        switch (event.status()) {
+            case PENDING -> charger.reserved();
+            case CONFIRMED -> charger.charging();
+            case CANCELLED, FAILED, COMPLETED -> charger.available();
+            default -> throw new IllegalArgumentException("올바르지 않은 예약 상태입니다.");
+        }
+
+        chargerRepository.save(charger);
+    }
+}

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/event/ReservationEvent.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/event/ReservationEvent.java
@@ -1,0 +1,10 @@
+package com.projectX.ChargerReserv.domain.reservation.event;
+
+import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
+
+public record ReservationEvent(
+        Long reservationId,
+        Long chargerId,
+        ReservationStatus status
+) {
+}

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/repository/ReservationRepository.java
@@ -29,7 +29,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
      * 특정 충전기 ID와 차량 번호를 기준으로 예약 정보를 조회합니다.
      *
      * @param uniqueChargerId 충전기의 고유 ID
-     * @param vehicleNumber 차량 번호
+     * @param vehicleNumber   차량 번호
      * @return 찾아진 예약 정보를 포함하는 Optional 객체
      */
     Optional<ReservationEntity> findByCharger_UniqueChargerIdAndVehicleNumber(Long uniqueChargerId, String vehicleNumber);
@@ -37,7 +37,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
     /**
      * 특정 사용자가 특정 상태의 예약을 가지고 있는지 여부를 반환합니다.
      *
-     * @param user 사용자 엔티티
+     * @param user   사용자 엔티티
      * @param status 예약 상태
      * @return 상태가 존재하면 true, 그렇지 않으면 false
      */
@@ -47,7 +47,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
      * 특정 충전기가 특정 상태의 예약을 가지고 있는지 여부를 반환합니다.
      *
      * @param charger 충전기 엔티티
-     * @param status 예약 상태
+     * @param status  예약 상태
      * @return 상태가 존재하면 true, 그렇지 않으면 false
      */
     boolean existsByChargerAndStatus(ChargerEntity charger, ReservationStatus status);
@@ -56,10 +56,10 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
      * 사용자 ID와 생성된 날짜의 범위를 기준으로 예약 목록을 조회하며,
      * 결과는 예약 생성 날짜 기준으로 최신 순으로 정렬됩니다.
      *
-     * @param userId 사용자 ID
+     * @param userId    사용자 ID
      * @param startDate 검색 시작 날짜, null 가능
-     * @param endDate 검색 종료 날짜, null 가능
-     * @param pageable 페이지네이션 및 정렬 정보
+     * @param endDate   검색 종료 날짜, null 가능
+     * @param pageable  페이지네이션 및 정렬 정보
      * @return 해당 기간과 사용자 ID에 맞는 예약 목록의 페이지
      */
     @Query("SELECT r FROM ReservationEntity r WHERE r.user.userId = :userId " +

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCancellationService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCancellationService.java
@@ -1,5 +1,7 @@
 package com.projectX.ChargerReserv.domain.reservation.service;
 
+import com.projectX.ChargerReserv.domain.charger.entity.ChargerEntity;
+import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
 import com.projectX.ChargerReserv.domain.reservation.dto.command.CancelReservationCommand;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class ReservationCancellationService {
 
     private final ReservationRepository reservationRepository;
+    private final ChargerRepository chargerRepository;
 
     public void cancelReservation(CancelReservationCommand command) {
         reservationRepository.findById(command.reservationId())
@@ -23,6 +26,12 @@ public class ReservationCancellationService {
                     if (reservation.getStatus() != ReservationStatus.PENDING) {
                         throw new IllegalStateException("예약을 취소할 수 없는 상태입니다.");
                     }
+                    ChargerEntity charger = chargerRepository.findById(reservation.getCharger().getChargerId())
+                            .orElseThrow(() -> new IllegalArgumentException("충전기를 찾을 수 없습니다."));
+
+                    charger.cancel();
+                    chargerRepository.save(charger);
+
                     reservation.cancel();
                     reservationRepository.save(reservation);
                 }, () -> {

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCompletionService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCompletionService.java
@@ -6,6 +6,7 @@ import com.projectX.ChargerReserv.domain.reservation.entity.ReservationEntity;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
 import com.projectX.ChargerReserv.global.error.IllegalArgumentException;
+import com.projectX.ChargerReserv.global.error.NoExistException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,9 @@ public class ReservationCompletionService {
             throw new IllegalArgumentException("예약 상태가 완료할 수 있는 상태가 아닙니다.");
         }
 
-        ChargerEntity charger = reservation.getCharger();
+        ChargerEntity charger = chargerRepository.findById(reservation.getCharger().getUniqueChargerId())
+                .orElseThrow(() -> new NoExistException("충전기를 찾을 수 없습니다."));
+
         charger.complete();
         chargerRepository.save(charger);
 

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCompletionService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCompletionService.java
@@ -1,5 +1,7 @@
 package com.projectX.ChargerReserv.domain.reservation.service;
 
+import com.projectX.ChargerReserv.domain.charger.entity.ChargerEntity;
+import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationEntity;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class ReservationCompletionService {
 
     private final ReservationRepository reservationRepository;
+    private final ChargerRepository chargerRepository;
 
     public void completeReservation(Long reservationId) {
         ReservationEntity reservation = reservationRepository.findById(reservationId)
@@ -22,6 +25,10 @@ public class ReservationCompletionService {
         if (reservation.getStatus() != ReservationStatus.CONFIRMED) {
             throw new IllegalArgumentException("예약 상태가 완료할 수 있는 상태가 아닙니다.");
         }
+
+        ChargerEntity charger = reservation.getCharger();
+        charger.complete();
+        chargerRepository.save(charger);
 
         reservation.complete();
         reservationRepository.save(reservation);

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCreationService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationCreationService.java
@@ -6,6 +6,7 @@ import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
 import com.projectX.ChargerReserv.domain.reservation.dto.command.CreateReservationCommand;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationEntity;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
+import com.projectX.ChargerReserv.domain.reservation.event.ReservationEvent;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
 import com.projectX.ChargerReserv.domain.user.entity.UserEntity;
 import com.projectX.ChargerReserv.domain.user.repository.UserRepository;
@@ -14,6 +15,7 @@ import com.projectX.ChargerReserv.global.error.NoExistException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -29,6 +31,7 @@ public class ReservationCreationService {
     private final UserRepository userRepository;
     private final ChargerRepository chargerRepository;
     private final RabbitTemplate rabbitTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 새로운 예약을 생성합니다.
@@ -42,15 +45,20 @@ public class ReservationCreationService {
         ChargerEntity charger = chargerRepository.findById(command.chargerId())
                 .orElseThrow(() -> new NoExistException("충전기를 찾을 수 없습니다."));
 
-        checkIfChargerAvailable(charger);
-        checkUserActiveReservations(user);
-
-        changeChargerStatusToReserved(charger);
+        validateReservation(user, charger);
 
         ReservationEntity reservation = createAndSaveReservation(command, user, charger);
+
+        eventPublisher.publishEvent(new ReservationEvent(reservation.getId(), charger.getUniqueChargerId(), ReservationStatus.PENDING));
+
         sendExpirationMessage(reservation.getId());
 
         return reservation.getId();
+    }
+
+    private void validateReservation(UserEntity user, ChargerEntity charger) {
+        checkIfChargerAvailable(charger);
+        checkUserActiveReservations(user);
     }
 
     private void checkIfChargerAvailable(ChargerEntity charger) {
@@ -64,11 +72,6 @@ public class ReservationCreationService {
         if (hasActiveReservations) {
             throw new IllegalStateException("사용자가 이미 활성화된 예약을 가지고 있습니다.");
         }
-    }
-
-    private void changeChargerStatusToReserved(ChargerEntity charger) {
-        charger.reserve();
-        chargerRepository.save(charger);
     }
 
     private ReservationEntity createAndSaveReservation(CreateReservationCommand command, UserEntity user, ChargerEntity charger) {

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
@@ -35,7 +35,7 @@ public class ReservationExpirationService {
                 charger.cancel();
                 chargerRepository.save(charger);
 
-                reservation.markAsFailed();
+                reservation.failed();
                 reservationRepository.save(reservation);
             }
         });

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
@@ -1,8 +1,11 @@
 package com.projectX.ChargerReserv.domain.reservation.service;
 
+import com.projectX.ChargerReserv.domain.charger.entity.ChargerEntity;
+import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
 import com.projectX.ChargerReserv.global.config.RabbitMQConfig;
+import com.projectX.ChargerReserv.global.error.NoExistException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class ReservationExpirationService {
 
     private final ReservationRepository reservationRepository;
+    private final ChargerRepository chargerRepository;
 
     /**
      * 예약 만료 메시지를 처리합니다.
@@ -26,6 +30,11 @@ public class ReservationExpirationService {
     public void handleReservationExpiration(Long reservationId) {
         reservationRepository.findById(reservationId).ifPresent(reservation -> {
             if (reservation.getStatus() == ReservationStatus.PENDING && reservation.isExpired()) {
+                ChargerEntity charger = chargerRepository.findById(reservation.getCharger().getUniqueChargerId())
+                        .orElseThrow(() -> new NoExistException("충전기를 찾을 수 없습니다."));
+                charger.cancel();
+                chargerRepository.save(charger);
+
                 reservation.markAsFailed();
                 reservationRepository.save(reservation);
             }

--- a/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/reservation/service/ReservationExpirationService.java
@@ -1,13 +1,12 @@
 package com.projectX.ChargerReserv.domain.reservation.service;
 
-import com.projectX.ChargerReserv.domain.charger.entity.ChargerEntity;
-import com.projectX.ChargerReserv.domain.charger.repository.ChargerRepository;
 import com.projectX.ChargerReserv.domain.reservation.entity.ReservationStatus;
+import com.projectX.ChargerReserv.domain.reservation.event.ReservationEvent;
 import com.projectX.ChargerReserv.domain.reservation.repository.ReservationRepository;
 import com.projectX.ChargerReserv.global.config.RabbitMQConfig;
-import com.projectX.ChargerReserv.global.error.NoExistException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -19,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class ReservationExpirationService {
 
     private final ReservationRepository reservationRepository;
-    private final ChargerRepository chargerRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 예약 만료 메시지를 처리합니다.
@@ -30,13 +29,10 @@ public class ReservationExpirationService {
     public void handleReservationExpiration(Long reservationId) {
         reservationRepository.findById(reservationId).ifPresent(reservation -> {
             if (reservation.getStatus() == ReservationStatus.PENDING && reservation.isExpired()) {
-                ChargerEntity charger = chargerRepository.findById(reservation.getCharger().getUniqueChargerId())
-                        .orElseThrow(() -> new NoExistException("충전기를 찾을 수 없습니다."));
-                charger.cancel();
-                chargerRepository.save(charger);
-
                 reservation.failed();
                 reservationRepository.save(reservation);
+
+                eventPublisher.publishEvent(new ReservationEvent(reservation.getId(), reservation.getCharger().getUniqueChargerId(), ReservationStatus.FAILED));
             }
         });
     }

--- a/src/main/java/com/projectX/ChargerReserv/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/projectX/ChargerReserv/domain/user/entity/UserEntity.java
@@ -29,8 +29,4 @@ public class UserEntity extends BasicEntity {
     private Long outhId;
 
     private String refreshToken;
-
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<ReservationEntity> reservationEntityList;
-
 }


### PR DESCRIPTION
- 동일한 충전기에 여러 사용자가 예약할 경우에 대한 동시성 처리를 위해, 충전기에 "예약 중" 상태가 필요하여 ChargerStauts에 "예약 중" 상태를 추가하였습니다. 더 자세한 사항은 맨 아래에 적어놓겠습니다.
- 또한, 낙관적 락을 사용하기 위해 ChargerEntity에 version 필드를 추가하였습니다. 그리고 상태를 변경시키는 메소드 3개를 추가하였습니다.
- 예약 도메인에서 충전기 상태를 변경하려고 하니 의존도가 너무 높은 것 같아 이벤트 처리로 구현하였습니다.
- 예약 패키지 내에 전체 정렬을 하였습니다.
- user <-> reservation, charger <-> reservation 양방향 매핑을 단방향 매핑으로 수정하였습니다.
- 이번 PR로 예약 생성, 예약 확인, 예약 사용자 취소, 예약 시간 만료 취소, 예약 완료(충전 완료), 예약 목록 조회, 예약 상세 조회 모든 기능 구현 완료하였습니다 ~

---

예약 생성 -> ReservationStatus를 예약 중으로 변경 -> ChargerStatus를 예약 중으로 변경
예약 확인 -> ReservationStatus를 확인으로 변경 -> ChargerStatus를 충전 중으로 변경
예약을 사용자가 취소 -> ReservationStatus를 취소로 변경 -> ChargerStatus를 사용가능으로 변경
예약이 시간 만료로 취소 -> ReservationStatus를 실패로 변경 -> ChargerStatus를 사용가능으로 변경
에약 완료 -> ReservationStatus를 완료로 변경 -> ChargerStatus를 사용가능으로 변경

